### PR TITLE
Update README.md

### DIFF
--- a/easy/README.md
+++ b/easy/README.md
@@ -53,7 +53,7 @@ kubectl version
 
 # Create Cluster
 ```
-# kind create cluster --loglevel debug
+# kind create cluster -v 3
 Creating cluster "kind" ...
  ✓ Ensuring node image (kindest/node:v1.17.0) 🖼
  ✓ Preparing nodes 📦


### PR DESCRIPTION
Replaced `--loglevel debug` with `-v 3`.

`--loglevel` is deprecated, and the loglevel `debug` is mapped to verbosity level `3` for compatibility.
See https://github.com/kubernetes-sigs/kind/blob/b6bc112522651d98c81823df56b7afa511459a3b/pkg/cmd/kind/root.go#L100 for detail.